### PR TITLE
delay 6s to wait ibc token recieve in the destination chain

### DIFF
--- a/networks/cosmos/starship/__tests__/token.test.ts
+++ b/networks/cosmos/starship/__tests__/token.test.ts
@@ -161,6 +161,8 @@ describe("Token transfers", () => {
 
     assertIsDeliverTxSuccess(resp);
 
+    await new Promise((resolve) => setTimeout(resolve, 6000));
+
     // Check osmos in address on cosmos chain
     const cosmosQueryClient = new RpcQuery(cosmosRpcEndpoint());
     const { balances } = await cosmosQueryClient.allBalances({


### PR DESCRIPTION
IBC tokens need to wait for at least 1 block to be received on the target chain
usually 5s for 1 block, so wait 6s and the test passed