### PR TITLE
use yarn starship wait-for-pods befor starship port forwarding

### DIFF
--- a/libs/interchainjs/package.json
+++ b/libs/interchainjs/package.json
@@ -27,7 +27,7 @@
     "starship:test": "jest --config ./jest.starship.config.js --verbose --bail",
     "starship:debug": "jest --config ./jest.starship.config.js --runInBand --verbose --bail",
     "starship:watch": "jest --watch --config ./jest.starship.config.js",
-    "starship:all": "yarn starship setup && sleep 10 && yarn starship deploy && sleep 300 && yarn starship get-pods && yarn starship start-ports && yarn starship port-pids",
+    "starship:all": "yarn starship setup && sleep 10 && yarn starship deploy && yarn starship wait-for-pods && yarn starship get-pods && yarn starship start-ports && yarn starship port-pids",
     "prepare": "npm run build"
   },
   "dependencies": {

--- a/networks/cosmos/starship/README.md
+++ b/networks/cosmos/starship/README.md
@@ -13,7 +13,9 @@ yarn starship get-pods
 yarn starship deploy
 
 # wait til STATUS=Running
-yarn starship get-pods
+yarn starship wait-for-pods
+or
+watch yarn starship get-pods
 
 # port forwarding
 yarn starship start-ports


### PR DESCRIPTION
300 seconds is not enough for my computer to deploy starship, use `yarn starship wait-for-pods` instead