### PR TITLE
fix: pubkey is Object case

### DIFF
--- a/networks/cosmos/src/workflows/plugins/signer-info.ts
+++ b/networks/cosmos/src/workflows/plugins/signer-info.ts
@@ -60,8 +60,13 @@ export class SignerInfoPlugin extends BaseWorkflowBuilderPlugin<
     // Get public key bytes - handle both AccountData (with pubkey property) and IAccount (with getPublicKey method)
     let pubkeyBytes: Uint8Array;
     if ('pubkey' in account && account.pubkey) {
-      // AccountData from OfflineSigner - has direct pubkey property
-      pubkeyBytes = account.pubkey;
+      if (account.pubkey instanceof Uint8Array) {
+        pubkeyBytes = account.pubkey;
+      } else {
+        // Convert object with numeric keys to Uint8Array
+        const values = Object.values(account.pubkey) as number[];
+        pubkeyBytes = new Uint8Array(values);
+      }
     } else if ('getPublicKey' in account && typeof account.getPublicKey === 'function') {
       // IAccount from IWallet - use getPublicKey method
       try {


### PR DESCRIPTION
There are cases where the plugin type cannot maintain Uint8Array and is passed as object.

<img width="490" height="345" alt="image" src="https://github.com/user-attachments/assets/8c4dffd3-b791-4795-a25c-26860cf7f443" />
