### PR TITLE
fix: set signerAddress

### DIFF
--- a/networks/cosmos/src/signers/direct-signer.ts
+++ b/networks/cosmos/src/signers/direct-signer.ts
@@ -35,6 +35,11 @@ export class DirectSigner extends BaseCosmosSigner implements ISigningClient {
       throw new Error('Signer address does not match');
     }
 
+    if (!!!args.options?.signerAddress) {
+      args.options.signerAddress = account.address;
+    }
+    
+
     // Create the direct workflow
     const workflow = new DirectWorkflow(this, {
       messages: args.messages,


### PR DESCRIPTION
Because in the code below we always need signerAddress in options

https://github.com/hyperweb-io/interchainjs/blob/10e4e50db58d61da4a10b89c3dc3e42a488cc0bc/networks/cosmos/src/workflows/plugins/signer-info.ts#L41-L45